### PR TITLE
dialogNotOpened event - fix #4

### DIFF
--- a/src/IPub/Twitter/UI/LoginDialog.php
+++ b/src/IPub/Twitter/UI/LoginDialog.php
@@ -34,6 +34,7 @@ use IPub\OAuth;
  * @author Adam Kadlec <adam.kadlec@fastybird.com>
  *
  * @method onResponse(LoginDialog $dialog)
+ * @method onDialogNotOpened(LoginDialog $dialog, Exception $ex)
  */
 class LoginDialog extends Application\UI\Control
 {
@@ -41,6 +42,11 @@ class LoginDialog extends Application\UI\Control
 	 * @var array of function(LoginDialog $dialog)
 	 */
 	public $onResponse = [];
+
+	/**
+	 * @var \Closure[]
+	 */
+	public $onDialogNotOpened = [];
 
 	/**
 	 * @var Twitter\Client
@@ -106,7 +112,12 @@ class LoginDialog extends Application\UI\Control
 	public function handleOpen()
 	{
 		if (!$this->client->getUser()) { // no user
-			$this->open();
+			try {
+				$this->open();
+			} catch (OAuth\Exceptions\IException $ex) {
+				$this->onDialogNotOpened($this, $ex);
+				throw $ex;
+			}
 		}
 
 		$this->onResponse($this);


### PR DESCRIPTION
Opravuje #4 . Problém byl v tom, obtainRequestToken, ktere se vola pri otevreni dialogu. Vyřešil jsem to odchycením exception a vyhozením eventu. Kde si to může člověk pořešit. Pokud máš nějaký lepší návrh sem s ním, ale mě to skoro denně vyhazovalo error 500 a chodil tak i mail s tracy a bylo to fakt pruda.
